### PR TITLE
Merged 1.02 release from CPAN, fix all Kwalitee issues, and improve doc

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,6 @@
 Revision history for Perl module Text::Abbrev
 
-1.03 2016-01-?? FLORA
+1.02_01 2016-01-?? FLORA
   * Tweaked format of this file to follow CPAN::Changes::Spec
   * Removed the name of the exported function (abbrev) from the NAME section.
     By convention the abstract is: <module-name> - <short description>

--- a/Changes
+++ b/Changes
@@ -1,3 +1,6 @@
+1.02  Tue, 11 Sep 2012 10:35:08 -0400
+  * Fix NAME section.
+
 1.01  Sat, 02 Jul 2011 00:12:42 +0200
   * First release to CPAN
 

--- a/Changes
+++ b/Changes
@@ -5,6 +5,7 @@ Revision history for Perl module Text::Abbrev
   * Removed the name of the exported function (abbrev) from the NAME section.
     By convention the abstract is: <module-name> - <short description>
   * Added use of strict and warnings, bumping min perl version to 5.006.
+  * Added a LICENSE section to pod, with the text for Perl_5 license
 
 1.02 2012-09-11 FLORA
   * Fix NAME section.

--- a/Changes
+++ b/Changes
@@ -7,6 +7,7 @@ Revision history for Perl module Text::Abbrev
   * Added use of strict and warnings, bumping min perl version to 5.006.
   * Added a LICENSE section to pod, with the text for Perl_5 license
   * Added github repo to the doc, and noted that it's a core module.
+  * Added some example expansions to the doc, to show what's going on
 
 1.02 2012-09-11 FLORA
   * Fix NAME section.

--- a/Changes
+++ b/Changes
@@ -1,7 +1,12 @@
-1.02  Tue, 11 Sep 2012 10:35:08 -0400
+Revision history for Perl module Text::Abbrev
+
+1.03 2016-01-?? FLORA
+  * Tweaked format of this file to follow CPAN::Changes::Spec
+
+1.02 2012-09-11 FLORA
   * Fix NAME section.
 
-1.01  Sat, 02 Jul 2011 00:12:42 +0200
+1.01 2011-07-01 FLORA
   * First release to CPAN
 
     Previously this module was only part of the Perl core. This release is

--- a/Changes
+++ b/Changes
@@ -4,6 +4,7 @@ Revision history for Perl module Text::Abbrev
   * Tweaked format of this file to follow CPAN::Changes::Spec
   * Removed the name of the exported function (abbrev) from the NAME section.
     By convention the abstract is: <module-name> - <short description>
+  * Added use of strict and warnings, bumping min perl version to 5.006.
 
 1.02 2012-09-11 FLORA
   * Fix NAME section.

--- a/Changes
+++ b/Changes
@@ -2,6 +2,8 @@ Revision history for Perl module Text::Abbrev
 
 1.03 2016-01-?? FLORA
   * Tweaked format of this file to follow CPAN::Changes::Spec
+  * Removed the name of the exported function (abbrev) from the NAME section.
+    By convention the abstract is: <module-name> - <short description>
 
 1.02 2012-09-11 FLORA
   * Fix NAME section.

--- a/Changes
+++ b/Changes
@@ -6,6 +6,7 @@ Revision history for Perl module Text::Abbrev
     By convention the abstract is: <module-name> - <short description>
   * Added use of strict and warnings, bumping min perl version to 5.006.
   * Added a LICENSE section to pod, with the text for Perl_5 license
+  * Added github repo to the doc, and noted that it's a core module.
 
 1.02 2012-09-11 FLORA
   * Fix NAME section.

--- a/dist.ini
+++ b/dist.ini
@@ -26,5 +26,7 @@ do_metadata = 1
 do_munging = 0
 
 [Prereqs]
-perl = 5.005
+perl     = 5.006
 Exporter = 0
+strict   = 0
+warnings = 0

--- a/dist.ini
+++ b/dist.ini
@@ -1,5 +1,5 @@
 name    = Text-Abbrev
-version = 1.02
+version = 1.02_01
 author  = The Perl 5 Porters
 license = Perl_5
 copyright_holder = The Perl 5 Porters
@@ -10,6 +10,7 @@ copyright_holder = The Perl 5 Porters
 
 [MetaConfig]
 [MetaJSON]
+[PkgVersion]
 [PodSyntaxTests]
 
 [MetaResources]

--- a/dist.ini
+++ b/dist.ini
@@ -1,5 +1,5 @@
 name    = Text-Abbrev
-version = 1.01
+version = 1.02
 author  = The Perl 5 Porters
 license = Perl_5
 copyright_holder = The Perl 5 Porters

--- a/lib/Text/Abbrev.pm
+++ b/lib/Text/Abbrev.pm
@@ -2,11 +2,11 @@ package Text::Abbrev;
 require 5.005;		# Probably works on earlier versions too.
 require Exporter;
 
-our $VERSION = '1.01';
+our $VERSION = '1.02';
 
 =head1 NAME
 
-abbrev - create an abbreviation table from a list
+Text::Abbrev - abbrev - create an abbreviation table from a list
 
 =head1 SYNOPSIS
 

--- a/lib/Text/Abbrev.pm
+++ b/lib/Text/Abbrev.pm
@@ -22,11 +22,38 @@ Text::Abbrev - create an abbreviation table from a list (e.g. of words)
 
 =head1 DESCRIPTION
 
-Stores all unambiguous truncations of each element of LIST
-as keys in the associative array referenced by C<$hashref>.
-The values are the original list elements.
+This module exports an C<abbrev> function that generates
+all unambiguous truncations of each string in a list of strings.
+Each truncation is returned as the key of a hash,
+with the value being the original string.
+
+For example, if you called the following:
+
+    %hash = abbrev qw(blue blood);
+
+You would get the following entries in C<%hash>:
+
+    blu   => blue
+    blue  => blue
+    blo   => blood
+    bloo  => blood
+    blood => blood
+
+Whereas if you called it with the list C<(red blood)>,
+you'd get the following:
+
+    r     => red
+    re    => red
+    red   => red
+    b     => blood
+    bl    => blood
+    blo   => blood
+    bloo  => blood
+    blood => blood
 
 =head1 EXAMPLE
+
+These illustrate the different ways you can call the C<abbrev> function:
 
     $hashref = abbrev qw(list edit send abort gripe);
 

--- a/lib/Text/Abbrev.pm
+++ b/lib/Text/Abbrev.pm
@@ -87,6 +87,16 @@ sub abbrev {
 
 1;
 
+=head1 REPOSITORY
+
+C<Text::Abbrev> is a core module -
+it has always been shipped with Perl 5.
+
+It is a dual-life module though,
+which means it also gets separate CPAN releases. 
+
+The repository for the CPAN releases: L<https://github.com/rafl/text-abbrev>
+
 =head1 LICENSE
 
 This program is free software;

--- a/lib/Text/Abbrev.pm
+++ b/lib/Text/Abbrev.pm
@@ -6,7 +6,6 @@ use warnings;
 
 require Exporter;
 
-our $VERSION = '1.03';
 our @ISA     = qw(Exporter);
 our @EXPORT  = qw(abbrev);
 

--- a/lib/Text/Abbrev.pm
+++ b/lib/Text/Abbrev.pm
@@ -2,11 +2,11 @@ package Text::Abbrev;
 require 5.005;		# Probably works on earlier versions too.
 require Exporter;
 
-our $VERSION = '1.02';
+our $VERSION = '1.03';
 
 =head1 NAME
 
-Text::Abbrev - abbrev - create an abbreviation table from a list
+Text::Abbrev - create an abbreviation table from a list (e.g. of words)
 
 =head1 SYNOPSIS
 

--- a/lib/Text/Abbrev.pm
+++ b/lib/Text/Abbrev.pm
@@ -86,3 +86,11 @@ sub abbrev {
 }
 
 1;
+
+=head1 LICENSE
+
+This program is free software;
+you can redistribute it and/or modify it under the same terms as Perl itself.
+
+=cut
+

--- a/lib/Text/Abbrev.pm
+++ b/lib/Text/Abbrev.pm
@@ -1,8 +1,14 @@
 package Text::Abbrev;
-require 5.005;		# Probably works on earlier versions too.
+
+use 5.006;
+use strict;
+use warnings;
+
 require Exporter;
 
 our $VERSION = '1.03';
+our @ISA     = qw(Exporter);
+our @EXPORT  = qw(abbrev);
 
 =head1 NAME
 
@@ -32,8 +38,6 @@ The values are the original list elements.
 
 =cut
 
-@ISA = qw(Exporter);
-@EXPORT = qw(abbrev);
 
 # Usage:
 #	abbrev \%foo, LIST;


### PR DESCRIPTION
Hi Florian,

I started by merging the 1.02 release from CPAN and tagging it 'v1.02'.

This started with wanting to improve the documentation. That ended up with:
- adding LICENSE section
- tweaked the format of the NAME section to follow the conventional format
- expanding the DESCRIPTION, including a worked example to show exactly what it does
- added repo to doc, and noted it's a dual-life core module
- I thought about adding an AUTHOR section, but no idea what would go in there

I added use of `strict` and `warnings`, and bumped the min perl version, both in the code and metadata.

I also added `[PkgVersion]` to `dist.ini`, so that `$VERSION` would be auto updated there.

Given all these changes, and how many dists ultimately depend on `Text::Abbrev`, it should have a developer release first, so I've set the version accordingly. If you're ok with it, I'd be happy to do the developer release myself, and watch the CPAN Testers results for [at least 8 days](http://neilb.org/2014/03/13/tester-rates.html), and then update the PR for you to do a non-developer release.

Shout if you would like anything changing here.

Cheers,
Neil
